### PR TITLE
fix: resolve `/quotes` return same records and caching feat

### DIFF
--- a/client/pages/docs.tsx
+++ b/client/pages/docs.tsx
@@ -39,14 +39,14 @@ export const API_GUIDES = [
 		},
 	},
 	{
-		heading: "Get 10 random quotes",
-		link: "10-quotes",
+		heading: "Get 5 random quotes (Pagination not supported)",
+		link: "5-quotes",
 		isPremium: false,
 		codeSample: {
 			request: `fetch("${API_ORIGIN}")
           .then((response) => response.json())
           .then((quotes) => console.log(quotes));`,
-			response: `[{ anime: "", character: "", content: "" }, // 9 more]`,
+			response: `[{ anime: "", character: "", content: "" }, // 4 more]`,
 		},
 	},
 
@@ -76,32 +76,32 @@ export const API_GUIDES = [
 		},
 	},
 	{
-		heading: "Get 10 quotes by anime title",
-		link: "10quotes-by-anime",
+		heading: "Get 5 quotes by anime title",
+		link: "5quotes-by-anime",
 		isPremium: true,
 		codeSample: {
 			request: `fetch("${API_ORIGIN}?anime=naruto")
           .then((response) => response.json())
           .then((quotes) => console.log(quotes));`,
-			response: `[{ anime: "Naruto", character: "", content: "" }, // 9 more]`,
+			response: `[{ anime: "Naruto", character: "", content: "" }, // 4 more]`,
 		},
 	},
 	{
-		heading: "Get 10 quotes by anime character",
-		link: "10quotes-by-character",
+		heading: "Get 5 quotes by anime character",
+		link: "5quotes-by-character",
 		isPremium: true,
 		codeSample: {
 			request: `fetch("${API_ORIGIN}?character=saitama")
           .then((response) => response.json())
           .then((quotes) => console.log(quotes));`,
-			response: `[{ anime: "", character: "Saitama", content: "" }, // 9 more]`,
+			response: `[{ anime: "", character: "Saitama", content: "" }, // 4 more]`,
 		},
 	},
 	{
 		heading: "Pagination",
 		isPremium: true,
 		subHeading:
-			"Pagination works only on the query endpoints. Default pagination count is 10 quotes per page.",
+			"Pagination works only on the query endpoints. Default pagination count is 5 quotes per page.",
 		link: "pagination",
 		codeSample: {
 			request: `fetch('${API_ORIGIN}?anime=naruto&page=2')
@@ -110,7 +110,7 @@ export const API_GUIDES = [
 
       // works on character queries too 👇
       // https://animechan.io/api/quotes?character=luffy&page=2`,
-			response: `[{ anime: "Naruto", character: "", content: "" }, // 9 more]`,
+			response: `[{ anime: "Naruto", character: "", content: "" }, // 4 more]`,
 		},
 	},
 ];

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"server:start": "pnpm --filter server start",
 		"dev": "concurrently \"pnpm server:dev\" \"pnpm client:dev\"",
 		"build": "pnpm client:build && pnpm server:build",
-		"start": "concurrently \"pnpm server:start\" \"pnpm client:start\""
+		"start": "concurrently \"pnpm server:start\" \"pnpm client:start\"",
+		"server:test": "pnpm --filter server test"
 	},
 	"dependencies": {
 		"concurrently": "^8.2.2"

--- a/server/src/controllers/quotes.ts
+++ b/server/src/controllers/quotes.ts
@@ -94,7 +94,7 @@ export const getQuotes = async (req: Request, res: Response) => {
 	// If no anime or character is provided, return 5 random records.
 	// Return 400 if tried with pagination, since it doesn't make sense
 	// to paginate a route that simply returns random records each time.
-	if (!anime || !character) {
+	if (!anime && !character) {
 		if (page > 1) {
 			return res
 				.status(400)

--- a/server/src/controllers/quotes.ts
+++ b/server/src/controllers/quotes.ts
@@ -91,9 +91,9 @@ export const getQuotes = async (req: Request, res: Response) => {
 	const character = req.query.character as string;
 	const page = Number.parseInt(req.query.page as string) || 1;
 
-	// If no anime or character is provided, return 10 random quotes.
+	// If no anime or character is provided, return 5 random records.
 	// Return 400 if tried with pagination, since it doesn't make sense
-	// to paginate a route that returns 10 random records each time.
+	// to paginate a route that simply returns random records each time.
 	if (!anime || !character) {
 		if (page > 1) {
 			return res

--- a/server/src/controllers/quotes.ts
+++ b/server/src/controllers/quotes.ts
@@ -149,6 +149,11 @@ export const getQuotes = async (req: Request, res: Response) => {
 			take: 5,
 			skip: 5 * (pageNumber - 1),
 		});
+
+		if (quotes.length === 0) {
+			return res.status(404).json({ error: "No matching quotes found" });
+		}
+
 		const formattedQuotes = quotes.map((q) => formatPrismaResponse(q));
 		res.status(200).json(formattedQuotes);
 	} catch (error) {

--- a/server/src/controllers/quotes.ts
+++ b/server/src/controllers/quotes.ts
@@ -144,8 +144,8 @@ export const getQuotes = async (req: Request, res: Response) => {
 					},
 				},
 			},
-			take: 10,
-			skip: 10 * (page - 1),
+			take: 5,
+			skip: 5 * (page - 1),
 		});
 		const formattedQuotes = quotes.map((q) => formatPrismaResponse(q));
 		res.status(200).json(formattedQuotes);

--- a/server/src/libs/auth.ts
+++ b/server/src/libs/auth.ts
@@ -5,48 +5,42 @@ import { redisClient } from "~/libs/redis";
 import { isProtectedEndpoint, isValidEndpoint } from "./auth.util";
 
 export const protectedRoutes = async (req: Request, res: Response, next: NextFunction) => {
-	// If endpoint is not valid at all, return 404
-	// No need to hit the Redis nor the main db.
-	if (!isValidEndpoint(req.originalUrl)) {
-		return res.status(404).json({ message: "Endpoint not found" });
-	}
-
 	// Verification for protected endpoints
 	const reqApiKey = req.headers["x-api-key"] as string;
 
-	if (!reqApiKey) {
-		// If no API key is provided and the requested endpoint is protected
-		// Return 401 immediately and end the request.
-		if (isProtectedEndpoint(req.originalUrl)) {
-			return res.status(401).json({ message: "Unauthorized. Missing API key!" });
+	if (reqApiKey) {
+		// Below we put all the validations if an potential API key
+		// is found in the incoming API request headers.
+		if (!reqApiKey.startsWith("ani-") || reqApiKey.length < 60) {
+			return res.status(401).json({ message: "Unauthorized. Invalid API key!" });
 		}
 
-		// If no API key is provided and the requested endpoint is FREE
-		// Continue to the request with IP based rate limiting.
-		return rateLimitOnIP(req, res, next);
-	}
+		// Check if the API key is already cached in Redis store.
+		// If it is that means, it is a valid key since we only store
+		// valid keys in Redis.
+		const cachedApiKey = await redisClient.get(`rl_api:${reqApiKey}`);
 
-	// Below we put all the validations if an potential API key
-	// is found in the incoming API request headers.
-	if (!reqApiKey.startsWith("ani-") || reqApiKey.length < 60) {
-		return res.status(401).json({ message: "Unauthorized. Invalid API key!" });
-	}
-
-	// Check if the API key is already cached in Redis store.
-	// If it is that means, it is a valid key since we only store
-	// valid keys in Redis.
-	const cachedApiKey = await redisClient.get(`rl_api:${reqApiKey}`);
-
-	// If it is not in the cache, lastly check if it is in the database
-	// and add it to the cache if found. Else return 401.
-	if (!cachedApiKey) {
-		const apiKeyObj = await prisma.apiKey.findUnique({
-			where: { key: reqApiKey },
-		});
-		if (!apiKeyObj) {
-			console.log("db check");
-			return res.status(401).json({ message: "Invalid API key" });
+		// If it is not in the cache, lastly check if it is in the database
+		// and add it to the cache if found. Else return 401.
+		if (!cachedApiKey) {
+			const apiKeyObj = await prisma.apiKey.findUnique({
+				where: { key: reqApiKey },
+			});
+			if (!apiKeyObj) {
+				console.log("db check");
+				return res.status(401).json({ message: "Invalid API key" });
+			}
 		}
+		return rateLimitOnApiKey(reqApiKey)(req, res, next);
 	}
-	return rateLimitOnApiKey(reqApiKey)(req, res, next);
+
+	// If no API key is provided and the requested endpoint is protected
+	// Return 401 immediately and end the request.
+	if (isProtectedEndpoint(req.originalUrl)) {
+		return res.status(401).json({ message: "Unauthorized. Missing API key!" });
+	}
+
+	// If no API key is provided and the requested endpoint is FREE
+	// Continue to the request with IP based rate limiting.
+	return rateLimitOnIP(req, res, next);
 };

--- a/server/src/libs/auth.util.ts
+++ b/server/src/libs/auth.util.ts
@@ -1,36 +1,25 @@
-const AVAILABLE_ENDPOINT_PATHS = ["/api/v1/quotes/", "/api/v1/quotes/random/"];
-
 const PROTECTED_ENDPOINTS_URLS = [
 	{
-		pathname: "/api/v1/quotes/",
+		pathname: "/api/v1/quotes",
 		params: ["anime", "character", "page"],
 	},
 	{
-		pathname: "/api/v1/quotes/random/",
+		pathname: "/api/v1/quotes/random",
 		params: ["anime", "character"],
 	},
 ];
 
-const addTrailingSlash = (path: string) => {
-	return path.endsWith("/") ? path : `${path}/`;
-};
-
-export const isValidEndpoint = (url: string) => {
-	const updatedPath = addTrailingSlash(url);
-	return AVAILABLE_ENDPOINT_PATHS.some((endpoint) => updatedPath.startsWith(endpoint));
-};
-
 export const isProtectedEndpoint = (url: string) => {
 	const { pathname, searchParams } = new URL(url, "https://animechan.io");
-	const updatedPath = addTrailingSlash(pathname);
 
-	if (!isValidEndpoint(updatedPath)) {
-		return false;
+	for (const endpoint of PROTECTED_ENDPOINTS_URLS) {
+		if (pathname.includes(endpoint.pathname)) {
+			for (const param of endpoint.params) {
+				if (searchParams.has(param)) {
+					return true;
+				}
+			}
+			return false;
+		}
 	}
-
-	return PROTECTED_ENDPOINTS_URLS.some((endpoint) => {
-		return (
-			updatedPath === endpoint.pathname && endpoint.params.some((param) => searchParams.get(param))
-		);
-	});
 };

--- a/server/test/auth.test.ts
+++ b/server/test/auth.test.ts
@@ -1,21 +1,7 @@
 import { expect, test } from "vitest";
-import { isValidEndpoint, isProtectedEndpoint } from "../src/libs/auth.util";
+import { isProtectedEndpoint } from "../src/libs/auth.util";
 
 const BASE_PATH = "/api/v1/";
-
-test("Should pass on valid API paths", () => {
-	expect(isValidEndpoint(`${BASE_PATH}quotes/random`)).toBeTruthy();
-	expect(isValidEndpoint(`${BASE_PATH}quotes/random/`)).toBeTruthy();
-	expect(isValidEndpoint(`${BASE_PATH}quotes`)).toBeTruthy();
-	expect(isValidEndpoint(`${BASE_PATH}quotes/`)).toBeTruthy();
-});
-
-test("should fail on invalid API paths", () => {
-	expect(isValidEndpoint(`${BASE_PATH}foo`)).toBeFalsy();
-	expect(isValidEndpoint(`${BASE_PATH}foo/bar`)).toBeFalsy();
-	expect(isValidEndpoint(`${BASE_PATH}foo/bar/baz`)).toBeFalsy();
-	expect(isValidEndpoint(`${BASE_PATH}?foo=bar`)).toBeFalsy();
-});
 
 test("Should pass on protected API urls", () => {
 	expect(isProtectedEndpoint(`${BASE_PATH}quotes/random?anime=naruto`)).toBeTruthy();


### PR DESCRIPTION
This PR fixes the issue of `/quotes` endpoint returning the same records on each request. Also refactored controller for this route to do caching of the total count of records for faster response time. It now returns 5 random records on this endpoint.

closes #115 
